### PR TITLE
Allow use of env vars, docs, and ping interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ Example:
 --endpoint https://example.com
 ```
 
+You can also run it with Docker compose. For example, a service in your `docker-compose.yml` might look like this using environment vars (recommended):
+
+```yaml
+services:
+  newt:
+    image: fosrl/newt
+    container_name: newt
+    restart: unless-stopped
+    environment:
+      - PANGOLIN_ENDPOINT=https://example.com
+      - NEWT_ID=2ix2t8xk22ubpfy 
+      - NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2 
+```
+
+You can also pass the CLI args to the container:
+
 ```yaml
 services:
   newt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  newt:
+    image: newttest
+    container_name: newt
+    restart: unless-stopped
+    environment:
+      - PANGOLIN_ENDPOINT=https://proxy.schwartznetwork.net 
+      - NEWT_ID=2ix2t8xk22ubpfy 
+      - NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2 
+      - LOG_LEVEL=DEBUG 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     container_name: newt
     restart: unless-stopped
     environment:
-      - PANGOLIN_ENDPOINT=https://proxy.schwartznetwork.net 
+      - PANGOLIN_ENDPOINT=https://example.com
       - NEWT_ID=2ix2t8xk22ubpfy 
       - NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2 
-      - LOG_LEVEL=DEBUG 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   newt:
-    image: newttest
+    image: fosrl/newt:latest
     container_name: newt
     restart: unless-stopped
     environment:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,10 @@
 #!/bin/sh
 
-# Sample from https://github.com/traefik/traefik-library-image/blob/5070edb25b03cca6802d75d5037576c840f73fdd/v3.1/alpine/entrypoint.sh
-
 set -e
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
     set -- newt "$@"
-fi
-
-# if our command is a valid newt subcommand, let's invoke it through newt instead
-# (this allows for "docker run newt version", etc)
-if newt "$1" --help >/dev/null 2>&1
-then
-    set -- newt "$@"
-else
-    echo "= '$1' is not a newt command: assuming shell execution." 1>&2
 fi
 
 exec "$@"

--- a/main.go
+++ b/main.go
@@ -112,6 +112,26 @@ func ping(tnet *netstack.Net, dst string) error {
 	return nil
 }
 
+func startPingCheck(tnet *netstack.Net, serverIP string, stopChan chan struct{}) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				err := ping(tnet, serverIP)
+				if err != nil {
+					logger.Warn("Periodic ping failed: %v", err)
+				}
+			case <-stopChan:
+				logger.Info("Stopping ping check")
+				return
+			}
+		}
+	}()
+}
+
 func pingWithRetry(tnet *netstack.Net, dst string) error {
 	const (
 		maxAttempts = 5
@@ -300,6 +320,9 @@ func main() {
 		client.Close()
 	})
 
+	pingStopChan := make(chan struct{})
+	defer close(pingStopChan)
+
 	// Register handlers for different message types
 	client.RegisterHandler("newt/wg/connect", func(msg websocket.WSMessage) {
 		logger.Info("Received registration message")
@@ -372,6 +395,11 @@ persistent_keepalive_interval=5`, fixKey(fmt.Sprintf("%s", privateKey)), fixKey(
 		if err != nil {
 			// Handle complete failure after all retries
 			logger.Error("Failed to ping %s: %v", wgData.ServerIP, err)
+		}
+
+		if !connected {
+			logger.Info("Starting ping check")
+			startPingCheck(tnet, wgData.ServerIP, pingStopChan)
 		}
 
 		// Create proxy manager

--- a/main.go
+++ b/main.go
@@ -222,13 +222,6 @@ func resolveDomain(domain string) (string, error) {
 	return ipAddr, nil
 }
 
-func getEnvWithDefault(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
-}
-
 func main() {
 	var (
 		endpoint   string
@@ -240,12 +233,28 @@ func main() {
 		logLevel   string
 	)
 
-	// Define CLI flags with default values from environment variables
-	flag.StringVar(&endpoint, "endpoint", os.Getenv("PANGOLIN_ENDPOINT"), "Endpoint of your pangolin server")
-	flag.StringVar(&id, "id", os.Getenv("NEWT_ID"), "Newt ID")
-	flag.StringVar(&secret, "secret", os.Getenv("NEWT_SECRET"), "Newt secret")
-	flag.StringVar(&dns, "dns", getEnvWithDefault("DEFAULT_DNS", "8.8.8.8"), "DNS server to use")
-	flag.StringVar(&logLevel, "log-level", getEnvWithDefault("LOG_LEVEL", "INFO"), "Log level (DEBUG, INFO, WARN, ERROR, FATAL)")
+	// if PANGOLIN_ENDPOINT, NEWT_ID, and NEWT_SECRET are set as environment variables, they will be used as default values
+	endpoint = os.Getenv("PANGOLIN_ENDPOINT")
+	id = os.Getenv("NEWT_ID")
+	secret = os.Getenv("NEWT_SECRET")
+	dns = os.Getenv("DNS")
+	logLevel = os.Getenv("LOG_LEVEL")
+
+	if endpoint == "" {
+		flag.StringVar(&endpoint, "endpoint", "", "Endpoint of your pangolin server")
+	}
+	if id == "" {
+		flag.StringVar(&id, "id", "", "Newt ID")
+	}
+	if secret == "" {
+		flag.StringVar(&secret, "secret", "", "Newt secret")
+	}
+	if dns == "" {
+		flag.StringVar(&dns, "dns", "8.8.8.8", "DNS server to use")
+	}
+	if logLevel == "" {
+		flag.StringVar(&logLevel, "log-level", "INFO", "Log level (DEBUG, INFO, WARN, ERROR, FATAL)")
+	}
 	flag.Parse()
 
 	logger.Init()


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This adds support for env config vars. It also adds a new function that pings the wg interface every 10 seconds to hopefully overcome any weird network failures like Pangolin restarting or ip changes.
