### PR TITLE
Add updown script capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ When Newt receives WireGuard control messages, it will use the information encod
 - `secret`: A unique secret (not shared and kept private) used to authenticate the client ID with the websocket in order to receive commands. 
 - `dns`: DNS server to use to resolve the endpoint
 - `log-level` (optional): The log level to use. Default: INFO
-
+- `updown` (optional): A script to be called when targets are added or removed.
+ 
 Example:
 
 ```bash
@@ -91,6 +92,18 @@ WantedBy=multi-user.target
 ```
 
 Make sure to `mv ./newt /usr/local/bin/newt`!
+
+### Updown
+
+You can pass in a updown script for Newt to call when it is adding or removing a target:
+
+`--updown "python3 test.py"`
+
+It will get called with args when a target is added: 
+`python3 test.py add tcp localhost:8556`
+`python3 test.py remove tcp localhost:8556`
+
+Returning a string from the script in the format of a target (`ip:dst` so `10.0.0.1:8080`) it will override the target and use this value instead to proxy.
 
 ## Build
 

--- a/updown.py
+++ b/updown.py
@@ -1,0 +1,77 @@
+"""
+Sample updown script for Newt proxy
+Usage: update.py <action> <protocol> <target>
+
+Parameters:
+- action: 'add' or 'remove'
+- protocol: 'tcp' or 'udp'
+- target: the target address in format 'host:port'
+
+If the action is 'add', the script can return a modified target that
+will be used instead of the original.
+"""
+
+import sys
+import logging
+import json
+from datetime import datetime
+
+# Configure logging
+LOG_FILE = "/tmp/newt-updown.log"
+logging.basicConfig(
+    filename=LOG_FILE,
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+def log_event(action, protocol, target):
+    """Log each event to a file for auditing purposes"""
+    timestamp = datetime.now().isoformat()
+    event = {
+        "timestamp": timestamp,
+        "action": action,
+        "protocol": protocol,
+        "target": target
+    }
+    logging.info(json.dumps(event))
+
+def handle_add(protocol, target):
+    """Handle 'add' action"""
+    logging.info(f"Adding {protocol} target: {target}")
+    
+def handle_remove(protocol, target):
+    """Handle 'remove' action"""
+    logging.info(f"Removing {protocol} target: {target}")
+    # For remove action, no return value is expected or used
+    
+def main():
+    # Check arguments
+    if len(sys.argv) != 4:
+        logging.error(f"Invalid arguments: {sys.argv}")
+        sys.exit(1)
+    
+    action = sys.argv[1]
+    protocol = sys.argv[2]
+    target = sys.argv[3]
+    
+    # Log the event
+    log_event(action, protocol, target)
+    
+    # Handle the action
+    if action == "add":
+        new_target = handle_add(protocol, target)
+        # Print the new target to stdout (if empty, no change will be made)
+        if new_target and new_target != target:
+            print(new_target)
+    elif action == "remove":
+        handle_remove(protocol, target)
+    else:
+        logging.error(f"Unknown action: {action}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logging.error(f"Unhandled exception: {e}")
+        sys.exit(1)


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Add ability to use an "updown" script. Example:
` --updown "/home/owen/.local/bin/python3 /home/owen/fossorial/test.py"`

It will get called with args when a target is added: 
`INFO: 2025/03/08 18:35:29 Executing updown script: /home/owen/.local/bin/python3 /home/owen/fossorial/test.py add tcp localhost:8556`