### PR TITLE
Cleanup & Updown Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ When Newt receives WireGuard control messages, it will use the information encod
 - `secret`: A unique secret (not shared and kept private) used to authenticate the client ID with the websocket in order to receive commands. 
 - `dns`: DNS server to use to resolve the endpoint
 - `log-level` (optional): The log level to use. Default: INFO
-
+- `updown` (optional): A script to be called when targets are added or removed.
+ 
 Example:
 
 ```bash
@@ -91,6 +92,18 @@ WantedBy=multi-user.target
 ```
 
 Make sure to `mv ./newt /usr/local/bin/newt`!
+
+### Updown
+
+You can pass in a updown script for Newt to call when it is adding or removing a target:
+
+`--updown "python3 test.py"`
+
+It will get called with args when a target is added: 
+`python3 test.py add tcp localhost:8556`
+`python3 test.py remove tcp localhost:8556`
+
+Returning a string from the script in the format of a target (`ip:dst` so `10.0.0.1:8080`) it will override the target and use this value instead to proxy.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ It will get called with args when a target is added:
 
 Returning a string from the script in the format of a target (`ip:dst` so `10.0.0.1:8080`) it will override the target and use this value instead to proxy.
 
+You can look at updown.py as a reference script to get started!
+
 ## Build
 
 ### Container 

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,19 @@ go 1.23.1
 
 toolchain go1.23.2
 
-require golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
+require (
+	github.com/gorilla/websocket v1.5.3
+	golang.org/x/net v0.30.0
+	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
+	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
+	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259
+)
 
 require (
 	github.com/google/btree v1.1.2 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
-	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
-	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6 // indirect
-	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
 golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
-golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=
-golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
 golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=

--- a/updown.py
+++ b/updown.py
@@ -1,0 +1,77 @@
+"""
+Sample updown script for Newt proxy
+Usage: update.py <action> <protocol> <target>
+
+Parameters:
+- action: 'add' or 'remove'
+- protocol: 'tcp' or 'udp'
+- target: the target address in format 'host:port'
+
+If the action is 'add', the script can return a modified target that
+will be used instead of the original.
+"""
+
+import sys
+import logging
+import json
+from datetime import datetime
+
+# Configure logging
+LOG_FILE = "/tmp/newt-updown.log"
+logging.basicConfig(
+    filename=LOG_FILE,
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+def log_event(action, protocol, target):
+    """Log each event to a file for auditing purposes"""
+    timestamp = datetime.now().isoformat()
+    event = {
+        "timestamp": timestamp,
+        "action": action,
+        "protocol": protocol,
+        "target": target
+    }
+    logging.info(json.dumps(event))
+
+def handle_add(protocol, target):
+    """Handle 'add' action"""
+    logging.info(f"Adding {protocol} target: {target}")
+    
+def handle_remove(protocol, target):
+    """Handle 'remove' action"""
+    logging.info(f"Removing {protocol} target: {target}")
+    # For remove action, no return value is expected or used
+    
+def main():
+    # Check arguments
+    if len(sys.argv) != 4:
+        logging.error(f"Invalid arguments: {sys.argv}")
+        sys.exit(1)
+    
+    action = sys.argv[1]
+    protocol = sys.argv[2]
+    target = sys.argv[3]
+    
+    # Log the event
+    log_event(action, protocol, target)
+    
+    # Handle the action
+    if action == "add":
+        new_target = handle_add(protocol, target)
+        # Print the new target to stdout (if empty, no change will be made)
+        if new_target and new_target != target:
+            print(new_target)
+    elif action == "remove":
+        handle_remove(protocol, target)
+    else:
+        logging.error(f"Unknown action: {action}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logging.error(f"Unhandled exception: {e}")
+        sys.exit(1)


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Add updown script to be called when adding or removing targets that can be used to manipulate targets.

You can pass in a updown script for Newt to call when it is adding or removing a target:

`--updown "python3 test.py"`

It will get called with args when a target is added: 
`python3 test.py add tcp localhost:8556`
`python3 test.py remove tcp localhost:8556`

Returning a string from the script in the format of a target (`ip:dst` so `10.0.0.1:8080`) it will override the target and use this value instead to proxy.