### PR TITLE
Feat: mTLS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 newt
 .DS_Store
 bin/
+.idea
+*.iml
+certs/

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ When Newt receives WireGuard control messages, it will use the information encod
 - `dns`: DNS server to use to resolve the endpoint
 - `log-level` (optional): The log level to use. Default: INFO
 - `updown` (optional): A script to be called when targets are added or removed.
- 
-Example:
+- `tls-client-cert` (optional): Client certificate (p12 or pfx) for mTLS. See [mTLS](#mtls)
+
+- Example:
 
 ```bash
 ./newt \
@@ -106,6 +107,38 @@ It will get called with args when a target is added:
 Returning a string from the script in the format of a target (`ip:dst` so `10.0.0.1:8080`) it will override the target and use this value instead to proxy.
 
 You can look at updown.py as a reference script to get started!
+
+### mTLS
+Newt supports mutual TLS (mTLS) authentication, if the server has been configured to request a client certificate.
+* Only PKCS12 (.p12 or .pfx) file format is accepted
+* The PKCS12 file must contain: 
+  * Private key
+  * Public certificate
+  * CA certificate
+* Encrypted PKCS12 files are currently not supported
+
+Examples:
+
+```bash
+./newt \
+--id 31frd0uzbjvp721 \
+--secret h51mmlknrvrwv8s4r1i210azhumt6isgbpyavxodibx1k2d6 \
+--endpoint https://example.com \
+--tls-client-cert /client.p12
+```
+
+```yaml
+services:
+  newt:
+    image: fosrl/newt
+    container_name: newt
+    restart: unless-stopped
+    environment:
+      - PANGOLIN_ENDPOINT=https://example.com
+      - NEWT_ID=2ix2t8xk22ubpfy 
+      - NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2 
+      - TLS_CLIENT_CERT=/client.p12 
+```
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Examples:
 --id 31frd0uzbjvp721 \
 --secret h51mmlknrvrwv8s4r1i210azhumt6isgbpyavxodibx1k2d6 \
 --endpoint https://example.com \
---tls-client-cert /client.p12
+--tls-client-cert ./client.p12
 ```
 
 ```yaml
@@ -137,7 +137,7 @@ services:
       - PANGOLIN_ENDPOINT=https://example.com
       - NEWT_ID=2ix2t8xk22ubpfy 
       - NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2 
-      - TLS_CLIENT_CERT=/client.p12 
+      - TLS_CLIENT_CERT=./client.p12 
 ```
 
 ## Build

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
 	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259
+	software.sslmate.com/src/go-pkcs12 v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -20,3 +20,5 @@ golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6 h1:CawjfCvY
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6/go.mod h1:3rxYc4HtVcSG9gVaTs2GEBdehh+sYPOwKtyUWEOTb80=
 gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 h1:TbRPT0HtzFP3Cno1zZo7yPzEEnfu8EjLfl6IU9VfqkQ=
 gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259/go.mod h1:AVgIgHMwK63XvmAzWG9vLQ41YnVHN0du0tEC46fI7yY=
+software.sslmate.com/src/go-pkcs12 v0.5.0 h1:EC6R394xgENTpZ4RltKydeDUjtlM5drOYIG9c6TVj2M=
+software.sslmate.com/src/go-pkcs12 v0.5.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/main.go
+++ b/main.go
@@ -321,13 +321,8 @@ func main() {
 	}
 	var opt websocket.ClientOption
 	if tlsPrivateKey != "" {
-		tlsConfig, err := websocket.LoadClientCertificate(tlsPrivateKey)
-		if err != nil {
-			logger.Fatal("Failed to load client certificate: %v", err)
-		}
-		opt = websocket.WithTLSConfig(tlsConfig)
+		opt = websocket.WithTLSConfig(tlsPrivateKey)
 	}
-
 	// Create a new client
 	client, err := websocket.NewClient(
 		id,     // CLI arg takes precedence

--- a/main.go
+++ b/main.go
@@ -561,10 +561,13 @@ persistent_keepalive_interval=5`, fixKey(fmt.Sprintf("%s", privateKey)), fixKey(
 	// Wait for interrupt signal
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	<-sigCh
+	sigReceived := <-sigCh
 
 	// Cleanup
-	dev.Close()
+	logger.Info("Received %s signal, stopping", sigReceived.String())
+	if dev != nil {
+		dev.Close()
+	}
 }
 
 func parseTargetData(data interface{}) (TargetData, error) {

--- a/self-signed-certs-for-mtls.sh
+++ b/self-signed-certs-for-mtls.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -eu
+
+echo -n "Enter username for certs (eg alice): "
+read CERT_USERNAME
+echo
+
+echo -n "Enter domain of user (eg example.com): "
+read DOMAIN
+echo
+
+# Prompt for password at the start
+echo -n "Enter password for certificate: "
+read -s PASSWORD
+echo
+echo -n "Confirm password: "
+read -s PASSWORD2
+echo
+
+if [ "$PASSWORD" != "$PASSWORD2" ]; then
+    echo "Passwords don't match!"
+    exit 1
+fi
+CA_DIR="./certs/ca"
+CLIENT_DIR="./certs/clients"
+FILE_PREFIX=$(echo "$CERT_USERNAME-at-$DOMAIN" | sed 's/\./-/')
+
+mkdir -p "$CA_DIR"
+mkdir -p "$CLIENT_DIR"
+
+if [ ! -f "$CA_DIR/ca.crt" ]; then
+# Generate CA private key
+  openssl genrsa -out "$CA_DIR/ca.key" 4096
+  echo "CA key ✅"
+
+  # Generate CA root certificate
+  openssl req -x509 -new -nodes \
+    -key "$CA_DIR/ca.key" \
+    -sha256 \
+    -days 3650 \
+    -out "$CA_DIR/ca.crt" \
+    -subj "/C=US/ST=State/L=City/O=Organization/OU=Unit/CN=ca.$DOMAIN"
+
+  echo "CA cert ✅"
+fi
+
+# Generate client private key
+openssl genrsa -aes256 -passout pass:"$PASSWORD" -out "$CLIENT_DIR/$FILE_PREFIX.key" 2048
+echo "Client key ✅"
+
+# Generate client Certificate Signing Request (CSR)
+openssl req -new \
+  -key "$CLIENT_DIR/$FILE_PREFIX.key" \
+  -out "$CLIENT_DIR/$FILE_PREFIX.csr" \
+  -passin pass:"$PASSWORD" \
+  -subj "/C=US/ST=State/L=City/O=Organization/OU=Unit/CN=$CERT_USERNAME@$DOMAIN"
+echo "Client cert ✅"
+
+echo -n "Signing client cert..."
+# Create client certificate configuration file
+cat > "$CLIENT_DIR/$FILE_PREFIX.ext" << EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = $DOMAIN
+EOF
+
+# Generate client certificate signed by CA
+openssl x509 -req \
+  -in "$CLIENT_DIR/$FILE_PREFIX.csr" \
+  -CA "$CA_DIR/ca.crt" \
+  -CAkey "$CA_DIR/ca.key" \
+  -CAcreateserial \
+  -out "$CLIENT_DIR/$FILE_PREFIX.crt" \
+  -days 365 \
+  -sha256 \
+  -extfile "$CLIENT_DIR/$FILE_PREFIX.ext"
+
+# Verify the client certificate
+openssl verify -CAfile "$CA_DIR/ca.crt" "$CLIENT_DIR/$FILE_PREFIX.crt"
+echo "Signed ✅"
+
+# Create encrypted PEM bundle
+openssl rsa -in "$CLIENT_DIR/$FILE_PREFIX.key" -passin pass:"$PASSWORD" \
+    | cat "$CLIENT_DIR/$FILE_PREFIX.crt" - > "$CLIENT_DIR/$FILE_PREFIX-bundle.enc.pem"
+
+
+# Convert to PKCS12
+echo "Converting to PKCS12 format..."
+openssl pkcs12 -export \
+  -out "$CLIENT_DIR/$FILE_PREFIX.enc.p12" \
+  -inkey "$CLIENT_DIR/$FILE_PREFIX.key" \
+  -in "$CLIENT_DIR/$FILE_PREFIX.crt" \
+  -certfile "$CA_DIR/ca.crt" \
+  -name "$CERT_USERNAME@$DOMAIN" \
+  -passin pass:"$PASSWORD" \
+  -passout pass:"$PASSWORD"
+echo "Converted to encrypted p12 for macOS ✅"
+
+# Convert to PKCS12 format without encryption
+echo "Converting to non-encrypted PKCS12 format..."
+openssl pkcs12 -export \
+  -out "$CLIENT_DIR/$FILE_PREFIX.p12" \
+  -inkey "$CLIENT_DIR/$FILE_PREFIX.key" \
+  -in "$CLIENT_DIR/$FILE_PREFIX.crt" \
+  -certfile "$CA_DIR/ca.crt" \
+  -name "$CERT_USERNAME@$DOMAIN" \
+  -passin pass:"$PASSWORD" \
+  -passout pass:""
+echo "Converted to non-encrypted p12  ✅"
+
+# Clean up intermediate files
+rm "$CLIENT_DIR/$FILE_PREFIX.csr" "$CLIENT_DIR/$FILE_PREFIX.ext" "$CA_DIR/ca.srl"
+echo
+echo
+
+echo "CA certificate:     $CA_DIR/ca.crt"
+echo "CA private key:     $CA_DIR/ca.key"
+echo "Client certificate: $CLIENT_DIR/$FILE_PREFIX.crt"
+echo "Client private key: $CLIENT_DIR/$FILE_PREFIX.key"
+echo "Client cert bundle: $CLIENT_DIR/$FILE_PREFIX.p12"
+echo "Client cert bundle (encrypted): $CLIENT_DIR/$FILE_PREFIX.enc.p12"

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -54,6 +54,13 @@ func (c *Client) loadConfig() error {
 	if c.config.Secret == "" {
 		c.config.Secret = config.Secret
 	}
+	if c.config.TlsClientCert == "" {
+		c.config.TlsClientCert = config.TlsClientCert
+	}
+	if c.config.Endpoint == "" {
+		c.config.Endpoint = config.Endpoint
+		c.baseURL = config.Endpoint
+	}
 	if c.config.Endpoint == "" {
 		c.config.Endpoint = config.Endpoint
 		c.baseURL = config.Endpoint

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -61,10 +61,6 @@ func (c *Client) loadConfig() error {
 		c.config.Endpoint = config.Endpoint
 		c.baseURL = config.Endpoint
 	}
-	if c.config.Endpoint == "" {
-		c.config.Endpoint = config.Endpoint
-		c.baseURL = config.Endpoint
-	}
 
 	return nil
 }

--- a/websocket/types.go
+++ b/websocket/types.go
@@ -1,10 +1,11 @@
 package websocket
 
 type Config struct {
-	NewtID   string `json:"newtId"`
-	Secret   string `json:"secret"`
-	Token    string `json:"token"`
-	Endpoint string `json:"endpoint"`
+	NewtID        string `json:"newtId"`
+	Secret        string `json:"secret"`
+	Token         string `json:"token"`
+	Endpoint      string `json:"endpoint"`
+	TlsClientCert string `json:"tlsClientCert"`
 }
 
 type TokenResponse struct {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR adds basic support for connecting to servers requiring a client certificate, aka mTLS. 
Some restrictions for now (all documented):
 * only p12 and pfx formats
 * key, cert and ca cert must all be present
 * encryption is NOT supported ( because I couldn't find a go module to decrypt all formats without weird error messages that'd be difficult to debug for enduser 

## How to test?
I am planning on a PR against the pangolin repo too with similar contents, but first, `newt` :) 
(This was tested only on macos so far)

### Positive test
1. Have a pangolin deployment
1. Generate custom certs. If you want an example, check `self-signed-certs-for-mtls.sh`
1. Modify a pangolin server's Traefik `dynamic_config.yaml` by adding the following
  ```yaml
  http:
    routers:
      next-router:
       # ...
        tls:
          certResolver: letsencrypt
          options: mtlsConfig
      api-router:
        # ...
        tls:
          certResolver: letsencrypt
          options: mtlsConfig
      ws-router:
        # ...
        tls:
          certResolver: letsencrypt
          options: mtlsConfig

  tls:
    options:
        mtlsConfig:
            clientAuth:
                clientAuthType: RequireAndVerifyClientCert
                caFiles:
                    - |
                        -----BEGIN CERTIFICATE-----
                        .... <content of the ca.cert>
                        -----END CERTIFICATE-----
  ```
1. Add the generated client cert, eg `alice-at-example-com.eng.12` to your client
  * On a **mac**
    1. double click, import to KeyChain, using the password. (You could also just import the non-encrypted version)
    2. Right click the imported item, `Get Info`
    3. Open `Trust`
    4. Set `SSL` to `Always Trust`
  * (Sry, haven't tested this on Linux or Windows, so can't describe )
1. Visit your admin pangolin portal using a browser supporting mTLS, and select the proposed cert.
1. Create a new Site, and copy the newt cli command
2. Start newt with the copied command, with the extra arg: `--tls-client-cert=./certs/clients/alice-at-example-com.p12`
3. Verify both in terminal and both in pangolin admin that the site is connected

### Negative test
1. Same as above but run newt without the `--tls-client-cert=...` arg. 
2. Verify error in terminal, explaining TLS connectivity issue.