### PR TITLE
feat: docker socket protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,27 @@ Newt can integrate with the Docker socket to provide remote inspection of Docker
 
 **Configuration:**
 
-You can specify the Docker socket path using the `--docker-socket` CLI argument or by setting the `DOCKER_SOCKET` environment variable. On most linux systems the socket is `/var/run/docker.sock`. When deploying newt as a container, you need to mount the host socket as a volume for the newt container to access it. If the Docker socket is not available or accessible, Newt will gracefully disable Docker integration and continue normal operation.
+You can specify the Docker socket path using the `--docker-socket` CLI argument or by setting the `DOCKER_SOCKET` environment variable. If the Docker socket is not available or accessible, Newt will gracefully disable Docker integration and continue normal operation.
+
+Supported values include:
+
+-   Local UNIX socket (default):
+    >You must mount the socket file into the container using a volume, so Newt can access it.
+
+    `unix:///var/run/docker.sock`
+
+-   TCP socket (e.g., via Docker Socket Proxy):
+
+    `tcp://localhost:2375`
+
+-   HTTP/HTTPS endpoints (e.g., remote Docker APIs):
+
+    `http://your-host:2375`
+
+-   SSH connections (experimental, requires SSH setup):
+
+    `ssh://user@host`
+
 
 ```yaml
 services:
@@ -219,8 +239,9 @@ services:
             - PANGOLIN_ENDPOINT=https://example.com
             - NEWT_ID=2ix2t8xk22ubpfy
             - NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2
-            - DOCKER_SOCKET=/var/run/docker.sock
+            - DOCKER_SOCKET=unix:///var/run/docker.sock
 ```
+>If you previously used just a path like `/var/run/docker.sock`, it still works — Newt assumes it is a UNIX socket by default.
 
 #### Hostnames vs IPs
 

--- a/docker/client.go
+++ b/docker/client.go
@@ -165,7 +165,7 @@ func ListContainers(socketPath string, enforceNetworkValidation bool) ([]Contain
 
 	// Create client with custom socket path
 	cli, err := client.NewClientWithOpts(
-		client.WithHost("unix://"+socketPath),
+		client.WithHost(socketPath),
 		client.WithAPIVersionNegotiation(),
 	)
 	if err != nil {
@@ -214,7 +214,6 @@ func ListContainers(socketPath string, enforceNetworkValidation bool) ([]Contain
 		if err == nil && containerInfo.Config != nil {
 			hostname = containerInfo.Config.Hostname
 		}
-
 
 		// Skip host container if set
 		if hostContainerId != "" && c.ID == hostContainerId {

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 		flag.StringVar(&tlsPrivateKey, "tls-client-cert", "", "Path to client certificate used for mTLS")
 	}
 	if dockerSocket == "" {
-		flag.StringVar(&dockerSocket, "docker-socket", "", "Path to Docker socket (typically /var/run/docker.sock)")
+		flag.StringVar(&dockerSocket, "docker-socket", "", "Path or address to Docker socket (typically unix:///var/run/docker.sock)")
 	}
 	if pingIntervalStr == "" {
 		flag.StringVar(&pingIntervalStr, "ping-interval", "3s", "Interval for pinging the server (default 3s)")


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Closes #62

This PR enhances Docker socket path handling in Newt by adding support for protocol-prefixed socket paths, such as:
- unix:///var/run/docker.sock
- tcp://localhost:2375
- http://127.0.0.1:2375
- ssh://user@host

The new parseDockerHost function extracts the protocol and address, allowing CheckSocket to validate reachability for multiple Docker API endpoints, not just local UNIX sockets.

## How to test?

### TCP Example with [linuxserver/docker-socket-proxy](https://github.com/linuxserver/docker-socket-proxy)

1. **Add socket proxy service to your newt-compose**

  * Example snippet
    ```yaml
      socket-proxy:
        image: ghcr.io/linuxserver/socket-proxy:3.2.3
        restart: unless-stopped
        environment:
          CONTAINERS: 1
          EVENTS: 1
          INFO: 1
          NETWORKS: 1
          PING: 1
          VERSION: 1
        volumes:
          - /var/run/docker.sock:/var/run/docker.sock:ro
        read_only: true
        tmpfs:
          - /run
        networks:
          - pangolin
    ```

2. **Run Newt with different socket protocols**
  * Command Argument:
    ```yaml
        command:
          - --docker-socket tcp://socket-proxy:2375
    ```
  * Environment Variable
    ```yaml
        environment:
          DOCKER_SOCKET: tcp://socket-proxy:2375
    ```

3. **Trigger the socket check from Pangolin**
  * Navigate to "Resources"
  * Edit a Resource
  * Targets Configuration -> IP / Hostname -> View Docker Containers
  * Observe logs for messages like:
    * Pangolin
      ```
      [info]: Docker socket availability for Newt id12345abc: available=true, socketPath=http://socket-proxy:2375
      ```
    * Newt
      ```
      DEBUG: 2025/07/30 12:41:15 Received Docker socket check request
      DEBUG: 2025/07/30 12:41:15 Docker reachable via tcp at socket-proxy:2375
      DEBUG: 2025/07/30 12:41:15 Sending message: newt/socket/status, data: map[available:true socketPath:http://socket-proxy:2375]
      INFO: 2025/07/30 12:41:15 Docker socket check response sent: available=true
      ```

4. **Verify container listing loads successfully in the Pangolin UI.**

5. **Optionally, test with invalid or unreachable paths to ensure graceful error handling.**