### PR TITLE
 Split mTLS client and CA certificates handling for improved TLS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ When Newt receives WireGuard control messages, it will use the information encod
 -   `ping-timeout` (optional): Timeout for each ping. Default: 5s
 -   `updown` (optional): A script to be called when targets are added or removed.
 -   `tls-client-cert` (optional): Client certificate (p12 or pfx) for mTLS. See [mTLS](#mtls)
+-   `tls-client-cert` (optional): Path to client certificate (PEM format, optional if using PKCS12). See [mTLS](#mtls)
+-   `tls-client-key` (optional): Path to private key for mTLS (PEM format, optional if using PKCS12)
+-   `tls-ca-cert` (optional): Path to CA certificate to verify server (PEM format, optional if using PKCS12)
 -   `docker-enforce-network-validation` (optional): Validate the container target is on the same network as the newt process. Default: false
 -   `health-file` (optional): Check if connection to WG server (pangolin) is ok. creates a file if ok, removes it if not ok. Can be used with docker healtcheck to restart newt
 -   `accept-clients` (optional): Enable WireGuard server mode to accept incoming olm client connections. Default: false
@@ -65,6 +68,9 @@ All CLI arguments can be set using environment variables as an alternative to co
 -   `PING_TIMEOUT`: Timeout for each ping. Default: 5s (equivalent to `--ping-timeout`)
 -   `UPDOWN_SCRIPT`: Path to updown script for target add/remove events (equivalent to `--updown`)
 -   `TLS_CLIENT_CERT`: Path to client certificate for mTLS (equivalent to `--tls-client-cert`)
+-   `TLS_CLIENT_CERT`: Path to client certificate for mTLS (equivalent to `--tls-client-cert`)
+-   `TLS_CLIENT_KEY`: Path to private key for mTLS (equivalent to `--tls-client-key`)
+-   `TLS_CA_CERT`: Path to CA certificate to verify server (equivalent to `--tls-ca-cert`)
 -   `DOCKER_ENFORCE_NETWORK_VALIDATION`: Validate container targets are on same network. Default: false (equivalent to `--docker-enforce-network-validation`)
 -   `HEALTH_FILE`: Path to health file for connection monitoring (equivalent to `--health-file`)
 -   `ACCEPT_CLIENTS`: Enable WireGuard server mode. Default: false (equivalent to `--accept-clients`)
@@ -259,16 +265,20 @@ You can look at updown.py as a reference script to get started!
 
 ### mTLS
 
-Newt supports mutual TLS (mTLS) authentication, if the server has been configured to request a client certificate.
+Newt supports mutual TLS (mTLS) authentication if the server is configured to request a client certificate. You can use either a PKCS12 (.p12/.pfx) file or split PEM files for the client cert, private key, and CA.
 
--   Only PKCS12 (.p12 or .pfx) file format is accepted
--   The PKCS12 file must contain:
-    -   Private key
-    -   Public certificate
-    -   CA certificate
--   Encrypted PKCS12 files are currently not supported
+#### Option 1: PKCS12 (Legacy)
 
-Examples:
+> This is the original method and still supported.
+
+* File must contain:
+
+  * Client private key
+  * Public certificate
+  * CA certificate
+* Encrypted `.p12` files are **not supported**
+
+Example:
 
 ```bash
 newt \
@@ -277,6 +287,27 @@ newt \
 --endpoint https://example.com \
 --tls-client-cert ./client.p12
 ```
+
+#### Option 2: Split PEM Files (Preferred)
+
+You can now provide separate files for:
+
+* `--tls-client-cert`: client certificate (`.crt` or `.pem`)
+* `--tls-client-key`: client private key (`.key` or `.pem`)
+* `--tls-ca-cert`: CA cert to verify the server
+
+Example:
+
+```bash
+newt \
+--id 31frd0uzbjvp721 \
+--secret h51mmlknrvrwv8s4r1i210azhumt6isgbpyavxodibx1k2d6 \
+--endpoint https://example.com \
+--tls-client-cert ./client.crt \
+--tls-client-key ./client.key \
+--tls-ca-cert ./ca.crt
+```
+
 
 ```yaml
 services:

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752308619,
-        "narHash": "sha256-pzrVLKRQNPrii06Rm09Q0i0dq3wt2t2pciT/GNq5EZQ=",
+        "lastModified": 1753489912,
+        "narHash": "sha256-uDCFHeXdRIgJpYmtcUxGEsZ+hYlLPBhR83fdU+vbC1s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "650e572363c091045cdbc5b36b0f4c1f614d3058",
+        "rev": "13e8d35b7d6028b7198f8186bc0347c6abaa2701",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,11 +27,11 @@
           default = self.packages.${system}.pangolin-newt;
           pangolin-newt = pkgs.buildGoModule {
             pname = "pangolin-newt";
-            version = "1.3.4";
+            version = "1.4.0";
 
             src = ./.;
 
-            vendorHash = "sha256-Y/f7GCO7Kf1iQiDR32DIEIGJdcN+PKS0OrhBvXiHvwo=";
+            vendorHash = "sha256-V8sq7XD/HJFKjhggrDWPdEEq3hjz0IHzpybQXA8Z/pg=";
 
             meta = with pkgs.lib; {
               description = "A tunneling client for Pangolin";

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fosrl/newt
 go 1.24
 
 require (
-	github.com/docker/docker v28.3.2+incompatible
+	github.com/docker/docker v28.3.3+incompatible
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/websocket v1.5.3
 	github.com/vishvananda/netlink v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v28.3.2+incompatible h1:wn66NJ6pWB1vBZIilP8G3qQPqHy5XymfYn5vsqeA5oA=
-github.com/docker/docker v28.3.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
+github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/main.go
+++ b/main.go
@@ -72,6 +72,18 @@ type ExitNodePingResult struct {
 	WasPreviouslyConnected bool    `json:"wasPreviouslyConnected"`
 }
 
+// Custom flag type for multiple CA files
+type stringSlice []string
+
+func (s *stringSlice) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *stringSlice) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
 var (
 	endpoint                           string
 	id                                 string
@@ -87,7 +99,6 @@ var (
 	keepInterface                      bool
 	acceptClients                      bool
 	updownScript                       string
-	tlsPrivateKey                      string
 	dockerSocket                       string
 	dockerEnforceNetworkValidation     string
 	dockerEnforceNetworkValidationBool bool
@@ -99,6 +110,14 @@ var (
 	healthFile                         string
 	useNativeInterface                 bool
 	authorizedKeysFile                 string
+	
+	// New mTLS configuration variables
+	tlsClientCert     string
+	tlsClientKey      string
+	tlsClientCAs      []string
+	
+	// Legacy PKCS12 support (deprecated)
+	tlsPrivateKey     string
 )
 
 func main() {
@@ -114,7 +133,6 @@ func main() {
 	generateAndSaveKeyTo = os.Getenv("GENERATE_AND_SAVE_KEY_TO")
 	keepInterface = os.Getenv("KEEP_INTERFACE") == "true"
 	acceptClients = os.Getenv("ACCEPT_CLIENTS") == "true"
-	tlsPrivateKey = os.Getenv("TLS_CLIENT_CERT")
 	dockerSocket = os.Getenv("DOCKER_SOCKET")
 	pingIntervalStr := os.Getenv("PING_INTERVAL")
 	pingTimeoutStr := os.Getenv("PING_TIMEOUT")
@@ -123,6 +141,25 @@ func main() {
 	useNativeInterface = os.Getenv("USE_NATIVE_INTERFACE") == "true"
 	// authorizedKeysFile = os.Getenv("AUTHORIZED_KEYS_FILE")
 	authorizedKeysFile = ""
+	
+	// Read new mTLS environment variables
+	tlsClientCert = os.Getenv("TLS_CLIENT_CERT")
+	tlsClientKey = os.Getenv("TLS_CLIENT_KEY")
+	tlsClientCAsEnv := os.Getenv("TLS_CLIENT_CAS")
+	if tlsClientCAsEnv != "" {
+		tlsClientCAs = strings.Split(tlsClientCAsEnv, ",")
+		// Trim spaces from each CA file path
+		for i, ca := range tlsClientCAs {
+			tlsClientCAs[i] = strings.TrimSpace(ca)
+		}
+	}
+	
+	// Legacy PKCS12 support (deprecated)
+	tlsPrivateKey = os.Getenv("TLS_CLIENT_CERT_PKCS12")
+	// Keep backward compatibility with old environment variable name
+	if tlsPrivateKey == "" {
+		tlsPrivateKey = os.Getenv("TLS_CLIENT_CERT")
+	}
 
 	if endpoint == "" {
 		flag.StringVar(&endpoint, "endpoint", "", "Endpoint of your pangolin server")
@@ -154,9 +191,6 @@ func main() {
 	flag.BoolVar(&keepInterface, "keep-interface", false, "Keep the WireGuard interface")
 	flag.BoolVar(&useNativeInterface, "native", false, "Use native WireGuard interface (requires WireGuard kernel module) and linux")
 	flag.BoolVar(&acceptClients, "accept-clients", false, "Accept clients on the WireGuard interface")
-	if tlsPrivateKey == "" {
-		flag.StringVar(&tlsPrivateKey, "tls-client-cert", "", "Path to client certificate used for mTLS")
-	}
 	if dockerSocket == "" {
 		flag.StringVar(&dockerSocket, "docker-socket", "", "Path to Docker socket (typically /var/run/docker.sock)")
 	}
@@ -172,6 +206,23 @@ func main() {
 	// if authorizedKeysFile == "" {
 	// 	flag.StringVar(&authorizedKeysFile, "authorized-keys-file", "~/.ssh/authorized_keys", "Path to authorized keys file (if unset, no keys will be authorized)")
 	// }
+
+	// Add new mTLS flags
+	if tlsClientCert == "" {
+		flag.StringVar(&tlsClientCert, "tls-client-cert-file", "", "Path to client certificate file (PEM/DER format)")
+	}
+	if tlsClientKey == "" {
+		flag.StringVar(&tlsClientKey, "tls-client-key", "", "Path to client private key file (PEM/DER format)")
+	}
+	
+	// Handle multiple CA files
+	var tlsClientCAsFlag stringSlice
+	flag.Var(&tlsClientCAsFlag, "tls-client-ca", "Path to CA certificate file for validating remote certificates (can be specified multiple times)")
+	
+	// Legacy PKCS12 flag (deprecated)
+	if tlsPrivateKey == "" {
+		flag.StringVar(&tlsPrivateKey, "tls-client-cert", "", "Path to client certificate (PKCS12 format) - DEPRECATED: use --tls-client-cert-file and --tls-client-key instead")
+	}
 
 	if pingIntervalStr != "" {
 		pingInterval, err = time.ParseDuration(pingIntervalStr)
@@ -197,13 +248,18 @@ func main() {
 		flag.StringVar(&dockerEnforceNetworkValidation, "docker-enforce-network-validation", "false", "Enforce validation of container on newt network (true or false)")
 	}
 	if healthFile == "" {
-		flag.StringVar(&healthFile, "health-file", "", "Path to health file (if unset, health file won’t be written)")
+		flag.StringVar(&healthFile, "health-file", "", "Path to health file (if unset, health file won't be written)")
 	}
 
 	// do a --version check
 	version := flag.Bool("version", false, "Print the version")
 
 	flag.Parse()
+
+	// Merge command line CA flags with environment variable CAs
+	if len(tlsClientCAsFlag) > 0 {
+		tlsClientCAs = append(tlsClientCAs, tlsClientCAsFlag...)
+	}
 
 	logger.Init()
 	loggerLevel := parseLogLevel(logLevel)
@@ -234,14 +290,42 @@ func main() {
 		dockerEnforceNetworkValidationBool = false
 	}
 
+	// Add TLS configuration validation
+	if err := validateTLSConfig(); err != nil {
+		logger.Fatal("TLS configuration error: %v", err)
+	}
+
+	// Show deprecation warning if using PKCS12
+	if tlsPrivateKey != "" {
+		logger.Warn("Using deprecated PKCS12 format for mTLS. Consider migrating to separate certificate files using --tls-client-cert-file, --tls-client-key, and --tls-client-ca")
+	}
+
 	privateKey, err = wgtypes.GeneratePrivateKey()
 	if err != nil {
 		logger.Fatal("Failed to generate private key: %v", err)
 	}
+	
+	// Create client option based on TLS configuration
 	var opt websocket.ClientOption
-	if tlsPrivateKey != "" {
-		opt = websocket.WithTLSConfig(tlsPrivateKey)
+	if tlsClientCert != "" && tlsClientKey != "" {
+		// Use new separate certificate configuration
+		opt = websocket.WithTLSConfig(websocket.TLSConfig{
+			ClientCertFile: tlsClientCert,
+			ClientKeyFile:  tlsClientKey,
+			CAFiles:        tlsClientCAs,
+		})
+		logger.Debug("Using separate certificate files for mTLS")
+		logger.Debug("Client cert: %s", tlsClientCert)
+		logger.Debug("Client key: %s", tlsClientKey) 
+		logger.Debug("CA files: %v", tlsClientCAs)
+	} else if tlsPrivateKey != "" {
+		// Use existing PKCS12 configuration for backward compatibility
+		opt = websocket.WithTLSConfig(websocket.TLSConfig{
+			PKCS12File: tlsPrivateKey,
+		})
+		logger.Debug("Using PKCS12 file for mTLS: %s", tlsPrivateKey)
 	}
+	
 	// Create a new client
 	client, err := websocket.NewClient(
 		"newt",
@@ -262,7 +346,21 @@ func main() {
 	logger.Debug("Endpoint: %v", endpoint)
 	logger.Debug("Log Level: %v", logLevel)
 	logger.Debug("Docker Network Validation Enabled: %v", dockerEnforceNetworkValidationBool)
-	logger.Debug("TLS Private Key Set: %v", tlsPrivateKey != "")
+	
+	// Add new TLS debug logging
+	if tlsClientCert != "" {
+		logger.Debug("TLS Client Cert File: %v", tlsClientCert)
+	}
+	if tlsClientKey != "" {
+		logger.Debug("TLS Client Key File: %v", tlsClientKey)
+	}
+	if len(tlsClientCAs) > 0 {
+		logger.Debug("TLS CA Files: %v", tlsClientCAs)
+	}
+	if tlsPrivateKey != "" {
+		logger.Debug("TLS PKCS12 File: %v", tlsPrivateKey)
+	}
+	
 	if dns != "" {
 		logger.Debug("Dns: %v", dns)
 	}
@@ -949,4 +1047,49 @@ persistent_keepalive_interval=5`, fixKey(privateKey.String()), fixKey(wgData.Pub
 	}
 	logger.Info("Exiting...")
 	os.Exit(0)
+}
+
+// validateTLSConfig validates the TLS configuration
+func validateTLSConfig() error {
+	// Check for conflicting configurations
+	pkcs12Specified := tlsPrivateKey != ""
+	separateFilesSpecified := tlsClientCert != "" || tlsClientKey != "" || len(tlsClientCAs) > 0
+	
+	if pkcs12Specified && separateFilesSpecified {
+		return fmt.Errorf("cannot use both PKCS12 format (--tls-client-cert) and separate certificate files (--tls-client-cert-file, --tls-client-key, --tls-client-ca)")
+	}
+	
+	// If using separate files, both cert and key are required
+	if (tlsClientCert != "" && tlsClientKey == "") || (tlsClientCert == "" && tlsClientKey != "") {
+		return fmt.Errorf("both --tls-client-cert-file and --tls-client-key must be specified together")
+	}
+	
+	// Validate certificate files exist
+	if tlsClientCert != "" {
+		if _, err := os.Stat(tlsClientCert); os.IsNotExist(err) {
+			return fmt.Errorf("client certificate file does not exist: %s", tlsClientCert)
+		}
+	}
+	
+	if tlsClientKey != "" {
+		if _, err := os.Stat(tlsClientKey); os.IsNotExist(err) {
+			return fmt.Errorf("client key file does not exist: %s", tlsClientKey)
+		}
+	}
+	
+	// Validate CA files exist
+	for _, caFile := range tlsClientCAs {
+		if _, err := os.Stat(caFile); os.IsNotExist(err) {
+			return fmt.Errorf("CA certificate file does not exist: %s", caFile)
+		}
+	}
+	
+	// Validate PKCS12 file exists if specified
+	if tlsPrivateKey != "" {
+		if _, err := os.Stat(tlsPrivateKey); os.IsNotExist(err) {
+			return fmt.Errorf("PKCS12 certificate file does not exist: %s", tlsPrivateKey)
+		}
+	}
+	
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -479,6 +479,11 @@ persistent_keepalive_interval=5`, fixKey(privateKey.String()), fixKey(wgData.Pub
 		// Close the WireGuard device and TUN
 		closeWgTunnel()
 
+		if stopFunc != nil {
+			stopFunc()     // stop the ws from sending more requests
+			stopFunc = nil // reset stopFunc to nil to avoid double stopping
+		}
+
 		// Mark as disconnected
 		connected = false
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This PR introduces a clearer separation between the mTLS client certificate/key and the CA certificate for the Newt service. The previous implementation used a single certificate path for both client authentication and CA verification. This change introduces the following:

* `--tls-client-cert-file`: Path to the client certificate used for mTLS
* `--tls-client-key`: Path to the private key associated with the client certificate
* `--tls-client-ca`: Path to the CA certificate used to verify the server

**Changes made**:

* Added three new CLI flags for TLS client certificate, key, and CA.
* Ensured backward compatibility by not removing any existing functionality.

## How to test?
**Testing**:
* Local Docker environment used to simulate mTLS using generated `client.key`, `client.crt`, and `ca.crt`.
* Verified failure when invalid paths are passed and success with correct certs.
* Confirmed mutual TLS handshake is successful with valid certs.

Closes #54 
