### PR TITLE
Update version to 1.4.1 and update version_replaceme when using nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,17 +22,25 @@
         system:
         let
           pkgs = pkgsFor system;
+
+          # Update version when releasing
+          version = "1.4.1";
+
+          # Update the version in a new source tree
+          srcWithReplacedVersion = pkgs.runCommand "newt-src-with-version" { } ''
+            cp -r ${./.} $out
+            chmod -R +w $out
+            rm -rf $out/.git $out/result $out/.envrc $out/.direnv
+            find $out -name "*.go" -type f -exec sed -i "s/version_replaceme/${version}/g" {} \;
+          '';
         in
         {
           default = self.packages.${system}.pangolin-newt;
           pangolin-newt = pkgs.buildGoModule {
             pname = "pangolin-newt";
-            version = "1.4.0";
-
-            src = ./.;
-
-            vendorHash = "sha256-V8sq7XD/HJFKjhggrDWPdEEq3hjz0IHzpybQXA8Z/pg=";
-
+            version = version;
+            src = srcWithReplacedVersion;
+            vendorHash = "sha256-PENsCO2yFxLVZNPgx2OP+gWVNfjJAfXkwWS7tzlm490=";
             meta = with pkgs.lib; {
               description = "A tunneling client for Pangolin";
               homepage = "https://github.com/fosrl/newt";


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

* Update flake.nix to 1.4.1
* When building using nix build, update `version_replaceme` in the code to the
  current version in flake.nix.

## How to test?

* Update version in flake.nix
* `nix build`
* `result/bin/newt -version` -> verify version is correctly output.
