### PR TITLE
Adding GHCR to CI/CD Release Workflow & further improvements

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   release:
     name: Build and Release
-    runs-on: ubuntu-latest
+    runs-on: amd64-runner
     # Job-level timeout to avoid runaway or stuck runs
     timeout-minutes: 120
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: amd64-runner
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description Copilot

This pull request enhances the CI/CD pipeline and test workflow for improved security, reliability, and container image handling. The main changes include pinning all GitHub Actions to specific commit SHAs, adding multi-registry container image publishing and signing (including dual-signing with Cosign), and improving runner consistency.

**CI/CD Workflow Improvements:**

* All GitHub Actions in `.github/workflows/cicd.yml` are now pinned to specific SHAs to reduce supply-chain risk. [[1]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0R3-R59) [[2]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0R72-R157)
* The pipeline now builds and pushes Docker images to both Docker Hub and GHCR, then mirrors images between registries using `skopeo`.
* Container images are dual-signed using Cosign (both keyless OIDC and key-based), and signatures are verified for both registries.
* Added job-level timeout and concurrency controls to prevent stuck or overlapping runs.
* Improved documentation and environment variable management for clarity and maintainability.

**Test Workflow Improvements:**

* The test workflow now uses the same self-hosted `amd64-runner` as the CI/CD pipeline for consistency.
* Actions in `.github/workflows/test.yml` are also pinned to specific SHAs.

## How to test?

