### PR TITLE
fix(nix): use new version number, update deps hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           inherit (pkgs) lib;
 
           # Update version when releasing
-          version = "1.6.0";
+          version = "1.6.1";
         in
         {
           default = self.packages.${system}.pangolin-newt;


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This syncs the Nix version again and also updates the vendor hash.

We can probably add a small action step in the future to build Nix packages, just in case. Or we can even use Nix in CI itself, because it's well suited for that purpose.

## How to test?

`nix build .#` should succeed on a fresh system.
