### PR TITLE
perf(proxy): add sync.Pool for UDP buffers

### DIFF
--- a/proxy/manager.go
+++ b/proxy/manager.go
@@ -23,8 +23,29 @@ import (
 
 const (
 	errUnsupportedProtoFmt = "unsupported protocol: %s"
-	maxUDPPacketSize       = 65507
+	maxUDPPacketSize       = 65507 // Maximum UDP packet size
 )
+
+// udpBufferPool provides reusable buffers for UDP packet handling.
+// This reduces GC pressure from frequent large allocations.
+var udpBufferPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, maxUDPPacketSize)
+		return &buf
+	},
+}
+
+// getUDPBuffer retrieves a buffer from the pool.
+func getUDPBuffer() *[]byte {
+	return udpBufferPool.Get().(*[]byte)
+}
+
+// putUDPBuffer clears and returns a buffer to the pool.
+func putUDPBuffer(buf *[]byte) {
+	// Clear the buffer to prevent data leakage
+	clear(*buf)
+	udpBufferPool.Put(buf)
+}
 
 // Target represents a proxy target with its address and port
 type Target struct {
@@ -555,7 +576,9 @@ func (pm *ProxyManager) handleTCPProxy(listener net.Listener, targetAddr string)
 }
 
 func (pm *ProxyManager) handleUDPProxy(conn *gonet.UDPConn, targetAddr string) {
-	buffer := make([]byte, maxUDPPacketSize) // Max UDP packet size
+	bufPtr := getUDPBuffer()
+	defer putUDPBuffer(bufPtr)
+	buffer := *bufPtr
 	clientConns := make(map[string]*net.UDPConn)
 	var clientsMutex sync.RWMutex
 
@@ -638,7 +661,10 @@ func (pm *ProxyManager) handleUDPProxy(conn *gonet.UDPConn, targetAddr string) {
 			go func(clientKey string, targetConn *net.UDPConn, remoteAddr net.Addr, tunnelID string) {
 				start := time.Now()
 				result := "success"
+				bufPtr := getUDPBuffer()
 				defer func() {
+					// Return buffer to pool first
+					putUDPBuffer(bufPtr)
 					// Always clean up when this goroutine exits
 					clientsMutex.Lock()
 					if storedConn, exists := clientConns[clientKey]; exists && storedConn == targetConn {
@@ -653,7 +679,7 @@ func (pm *ProxyManager) handleUDPProxy(conn *gonet.UDPConn, targetAddr string) {
 					telemetry.IncProxyConnectionEvent(context.Background(), tunnelID, "udp", telemetry.ProxyConnectionClosed)
 				}()
 
-				buffer := make([]byte, maxUDPPacketSize)
+				buffer := *bufPtr
 				for {
 					n, _, err := targetConn.ReadFromUDP(buffer)
 					if err != nil {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

- Add udpBufferPool for reusable 65507-byte UDP packet buffers
- Add getUDPBuffer() and putUDPBuffer() helper functions
- Clear buffer contents before returning to pool to prevent data leakage
- Apply pooling to both main handler buffer and per-client goroutine buffers
- Reduces GC pressure from frequent large allocations during UDP proxying

## How to test?

Internal code changes.