### PR TITLE
fix(healthcheck): Support ipv6 healthchecks

### DIFF
--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -365,11 +367,12 @@ func (m *Monitor) performHealthCheck(target *Target) {
 	target.LastCheck = time.Now()
 	target.LastError = ""
 
-	// Build URL
-	url := fmt.Sprintf("%s://%s", target.Config.Scheme, target.Config.Hostname)
+	// Build URL (use net.JoinHostPort to properly handle IPv6 addresses with ports)
+	host := target.Config.Hostname
 	if target.Config.Port > 0 {
-		url = fmt.Sprintf("%s:%d", url, target.Config.Port)
+		host = net.JoinHostPort(target.Config.Hostname, strconv.Itoa(target.Config.Port))
 	}
+	url := fmt.Sprintf("%s://%s", target.Config.Scheme, host)
 	if target.Config.Path != "" {
 		if !strings.HasPrefix(target.Config.Path, "/") {
 			url += "/"


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Currently we are doing fmt.sprintf on hostname and port which will not properly handle ipv6 addresses, instead of changing pangolin to send bracketed address a simply net.join can do this for us since we dont need to parse a formatted string

## How to test?

Enabling healthchecks on a ipv6 address will now work as intended.
