### PR TITLE
fix: stop orphaned health checks after public resource is deleted (#308)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1296,7 +1296,7 @@ persistent_keepalive_interval=5`, util.FixKey(privateKey.String()), util.FixKey(
 
 		// Define the sync data structure
 		type SyncData struct {
-			Targets            TargetsByType        `json:"targets"`
+			Targets            TargetsByType        `json:"proxyTargets"`
 			HealthCheckTargets []healthcheck.Config `json:"healthCheckTargets"`
 		}
 
@@ -1421,12 +1421,12 @@ persistent_keepalive_interval=5`, util.FixKey(privateKey.String()), util.FixKey(
 		// 	}
 		// }
 
-		// // Sync health check targets
-		// if err := healthMonitor.SyncTargets(syncData.HealthCheckTargets); err != nil {
-		// 	logger.Error("Failed to sync health check targets: %v", err)
-		// } else {
-		// 	logger.Info("Successfully synced health check targets")
-		// }
+		// Sync health check targets
+		if err := healthMonitor.SyncTargets(syncData.HealthCheckTargets); err != nil {
+			logger.Error("Failed to sync health check targets: %v", err)
+		} else {
+			logger.Info("Successfully synced health check targets")
+		}
 
 		logger.Info("Sync complete")
 	})


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
- Fixed a JSON key mismatch (targets → proxyTargets) that prevented Newt from reading the sync payload from Pangolin.
- Enabled  healthMonitor.SyncTargets() so that on each ping cycle health checks for resources matches with updates in Pangolin.
