### PR TITLE
fix(http): Set host header based on in

### DIFF
--- a/netstack2/http_handler.go
+++ b/netstack2/http_handler.go
@@ -291,6 +291,9 @@ func (h *HTTPHandler) getProxy(target HTTPTarget) *httputil.ReverseProxy {
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(targetURL)
+			if host := pr.In.Host; host != "" {
+				pr.Out.Host = host
+			}
 			// SetXForwarded sets X-Forwarded-For from the inbound request's
 			// RemoteAddr (the WireGuard/netstack client address), along with
 			// X-Forwarded-Host and X-Forwarded-Proto. Using Rewrite instead of


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

fix https://github.com/fosrl/pangolin/issues/2952 issue by setting the incoming host header to the outgoing one by the reverse proxy, this was the default behaviour when using single proxy but now since we use more features it now rewrites the host header

## How to test?

The downstream application should now receive the same host header that was sent by the client.
