### PR TITLE
fix(netstack2): forward TLS ConnectionState through httpConnCtx

### DIFF
--- a/netstack2/http_handler.go
+++ b/netstack2/http_handler.go
@@ -140,6 +140,17 @@ type httpConnCtx struct {
 	isTLS bool // true when the conn was wrapped with tls.Server
 }
 
+// ConnectionState forwards TLS connection state when the wrapped connection
+// exposes it; plain TCP connections return the zero value.
+func (c *httpConnCtx) ConnectionState() tls.ConnectionState {
+	if cs, ok := c.Conn.(interface {
+		ConnectionState() tls.ConnectionState
+	}); ok {
+		return cs.ConnectionState()
+	}
+	return tls.ConnectionState{}
+}
+
 // connCtxKey is the unexported context key used to store a *SubnetRule on the
 // per-connection context created by http.Server.ConnContext.
 type connCtxKey struct{}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Adds ConnectionState() to httpConnCtx so wrapped TLS connections expose their
TLS state to callers. This fixes the netstack2 TLS test added in 1.12.5, where
httpConnCtx is expected to forward ConnectionState() when the underlying conn
supports it.

Test that fails before this fix:

```
 ╔ |0| 11:29:59 | framework | ~/dev/src/newt  (fix/httpconnctx-connectionstate)                                        
 ╚═ $ go test ./netstack2                                                                                              
# github.com/fosrl/newt/netstack2 [github.com/fosrl/newt/netstack2.test]                                               
netstack2/http_handler_tls_test.go:31:17: wrapped.ConnectionState undefined (type *httpConnCtx has no field or method C
onnectionState)                                                                                                        
netstack2/http_handler_tls_test.go:43:17: wrapped.ConnectionState undefined (type *httpConnCtx has no field or method C
onnectionState)                                                                                                        
FAIL    github.com/fosrl/newt/netstack2 [build failed]                                                                 
FAIL  
```

## How to test?

All go tests pass.

