### PR TITLE
feat(ci): run a go test before we build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,20 @@ on:
       - dev
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 1.25
+
+      - name: Run Go tests
+        run: make test
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all local docker-build docker-build-release
+.PHONY: all local test docker-build docker-build-release
 
 all: local
 
@@ -7,6 +7,9 @@ LDFLAGS = -X main.newtVersion=$(VERSION)
 
 local:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o ./bin/newt
+
+test:
+	go test ./...
 
 docker-build:
 	docker build -t fosrl/newt:latest .


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
It doesn't look like there are any go tests being automatically ran as part of CI, as a result 1.12.5 broke the tests (Fix for that in https://github.com/fosrl/newt/pull/357)

This PR adds a phony test make target and updates the already existing test workflow that was just doing a go build to now call the test make target before a build happens.

## How to test?

Merge to `main` or `dev` after merging https://github.com/fosrl/newt/pull/357 (since go tests are broken) and verify that the Github workflow runs without issues.