### PR TITLE
Use Go version specified in go.mod for CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25
+          go-version-file: go.mod
 
       - name: Run Go tests
         run: make test
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25
+          go-version-file: go.mod
 
       - name: Build targets via `make`
         run: make ${{ matrix.target }}


### PR DESCRIPTION
## Description was generated by AI

This pull request updates the GitHub Actions workflow configuration to improve how the Go version is set up in CI jobs. Instead of specifying the Go version directly, it now uses the `go.mod` file to determine the correct version, ensuring consistency with the project's dependencies.

Workflow improvements:

* Updated the `Set up Go` step in `.github/workflows/test.yml` to use `go-version-file: go.mod` instead of hardcoding the Go version, both for running tests and building targets. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L22-R22) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L50-R50)

## How to test?

