### PR TITLE
fix: remove duplicate wrong error log in socket/fetch and dead code in reliablePing

### DIFF
--- a/common.go
+++ b/common.go
@@ -121,19 +121,11 @@ func reliablePing(tnet *netstack.Net, dst string, baseTimeout time.Duration, max
 		totalLatency += latency
 		successCount++
 
-		// If we get at least one success, we can return early for health checks
-		if successCount > 0 {
-			avgLatency := totalLatency / time.Duration(successCount)
-			// logger.Debug("Reliable ping succeeded after %d attempts, avg latency: %v", attempt, avgLatency)
-			return avgLatency, nil
-		}
+		// Return on first success
+		return totalLatency / time.Duration(successCount), nil
 	}
 
-	if successCount == 0 {
-		return 0, fmt.Errorf("all %d ping attempts failed, last error: %v", maxAttempts, lastErr)
-	}
-
-	return totalLatency / time.Duration(successCount), nil
+	return 0, fmt.Errorf("all %d ping attempts failed, last error: %v", maxAttempts, lastErr)
 }
 
 func pingWithRetry(tnet *netstack.Net, dst string, timeout time.Duration) (stopChan chan struct{}, err error) {

--- a/main.go
+++ b/main.go
@@ -1483,10 +1483,6 @@ persistent_keepalive_interval=5`, util.FixKey(privateKey.String()), util.FixKey(
 			"containers": containers,
 		})
 		if err != nil {
-			logger.Error("Failed to send registration message: %v", err)
-		}
-
-		if err != nil {
 			logger.Error("Failed to send Docker container list: %v", err)
 		} else {
 			logger.Debug("Docker container list sent, count: %d", len(containers))


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Two small bugs fixed:

**1. Wrong log message in `newt/socket/fetch` handler (`main.go`)**

After `client.SendMessage("newt/socket/containers", ...)` there were two back-to-back `if err != nil` checks on the same var. The first one had a copy-pasted message from a different handler: `"Failed to send registration message"` -- totally wrong context. On any send error you'd see that bogus line logged first, then the correct one right after. Dropped the duplicate stale block, kept the one with the right message.

**2. Dead code in `reliablePing` (`common.go`)**

`successCount` starts at 0 and is only incremented once before the `if successCount > 0` guard -- so that condition is always true when reached. The function always returned there, making everything after the loop unreachable. Removed the always-true guard and the dead post-loop code, left the behavior identical.

## How to test?

Bug 1 -- check the `newt/socket/fetch` handler in `main.go`. With the old code, any error from `client.SendMessage` would log `"Failed to send registration message"` (wrong) followed by `"Failed to send Docker container list"` (right). Now only the correct line fires.

Bug 2 -- static analysis or a quick read: `successCount++` immediately before `if successCount > 0` guarantees the condition, making the post-loop `if successCount == 0` branch and final `return` unreachable. Behavior is unchanged, code is just honest now.