### PR TITLE
fix: preserve the pending WireGuard registration chain

### DIFF
--- a/newt/handlers.go
+++ b/newt/handlers.go
@@ -1010,7 +1010,9 @@ func (n *Newt) registerHandlers(ctx context.Context) {
 		}
 
 		bcChainId := generateChainId()
-		n.pendingRegisterChainId = bcChainId
+		// Pangolin intentionally does not answer backwards-compatible
+		// registrations with newt/wg/connect. Do not replace the chain ID of
+		// the real registration while its response may already be in flight.
 		if err := n.client.SendMessage(topicWGRegister, map[string]interface{}{
 			"publicKey":           n.publicKey.String(),
 			"newtVersion":         n.config.Version,

--- a/newt/ping.go
+++ b/newt/ping.go
@@ -280,7 +280,8 @@ func (n *Newt) startPingCheck(fn pingFunc, serverIP, tunnelID string) chan struc
 							"chainId": pingChainId,
 						}, 3*time.Second)
 						bcChainId := generateChainId()
-						n.pendingRegisterChainId = bcChainId
+						// This compatibility message has no wg/connect response and must
+						// not supersede the pending real registration chain.
 						if err := n.client.SendMessage("newt/wg/register", map[string]interface{}{
 							"publicKey":           n.publicKey.String(),
 							"backwardsCompatible": true,


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Newt sends a normal WireGuard registration and a backwards-compatible registration during startup. The normal registration stores a chain ID and waits for `newt/wg/connect`. The compatibility message also replaced that stored ID, even though Pangolin intentionally does not answer compatibility registrations with `newt/wg/connect`.

When the compatibility message ran while the normal response was in flight, Newt rejected the valid response as stale and never initialized its WireGuard tunnel. The websocket stayed connected, which made the site look online while private client connectivity timed out.

This change keeps backwards-compatible registrations from touching `pendingRegisterChainId` in both places where they are sent. Normal registrations still set and validate their chain IDs as before.

Fixes #423

## How to test?

- Run `go test ./...`.
- Start Newt with client connectivity enabled and `LOG_LEVEL=DEBUG`.
- Confirm that the normal `newt/wg/connect` response is accepted instead of being discarded with different received and expected chain IDs.
- Confirm that Newt logs `Tunnel connection to server established successfully` and client connectivity becomes available.

I also tested this as a patched Newt 1.15.0 binary against Pangolin 1.21.0. Before the patch, the valid registration response was consistently discarded and WireGuard remained uninitialized. After the patch, Newt established the tunnel, Gerbil recorded a current handshake, and the private resource was reachable.
